### PR TITLE
Fix skipped subcommands and add regression test

### DIFF
--- a/kicapp/kicapp/console.py
+++ b/kicapp/kicapp/console.py
@@ -15,7 +15,8 @@ logger = logging.getLogger(__name__)
 @click.option("-v", "--verbose", is_flag=True, default=False, help="Enable verbose messages.")
 @click.version_option()
 @click.option("--logging-demo", is_flag=True, default=False, hidden=True)
-def cli(quiet: bool, verbose: bool, logging_demo: bool) -> None:  # noqa: FBT001 Booleans are in the user interface
+@click.pass_context
+def cli(ctx: click.Context, quiet: bool, verbose: bool, logging_demo: bool) -> None:  # noqa: FBT001 Booleans are in the user interface
     """Run a command to prepare EDA files for importing into KiCad."""
     log_level = get_logging_level(quiet, verbose)
 
@@ -23,6 +24,8 @@ def cli(quiet: bool, verbose: bool, logging_demo: bool) -> None:  # noqa: FBT001
 
     if logging_demo:
         kicapp.click_logging.show_logging_demo(logger)
+    elif ctx.invoked_subcommand:
+        pass
     else:
         cli(["--help"])
 

--- a/kicapp/tests/test_console.py
+++ b/kicapp/tests/test_console.py
@@ -2,6 +2,7 @@
 
 import logging
 
+import click
 import pytest
 from click.testing import CliRunner
 
@@ -14,6 +15,25 @@ def test_console():  # noqa: ANN201
     result = runner.invoke(console.cli)
     assert result.exit_code == 0
     assert "Show this message and exit." in result.output
+
+
+def test_subcommand():  # noqa: ANN201
+    """Does it invoke a subcommand?"""
+    command_was_invoked_message = "subcommand_name invoked"
+
+    @click.command("subcommand_name")
+    def subcommand_name() -> None:
+        print(command_was_invoked_message)
+
+    console.cli.add_command(subcommand_name)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        console.cli,
+        args=["subcommand_name"],
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip() == command_was_invoked_message
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
If you specify a subcommand on the command line, the program exits early because it calls back to itself with `--help`, which exits after printing the usage.

If the context has an `invoked_subcommand`, allow the program to continue execution.